### PR TITLE
<hotfix> Resolved bug that only showed Testimonials in VN

### DIFF
--- a/pages/about.js
+++ b/pages/about.js
@@ -57,6 +57,7 @@ const About = ({ EN }) => {
           <Testimonials
             testimonialsCounter={testimonialsCounter}
             setTestimonialsCounter={setTestimonialsCounter}
+            EN={EN}
           />
           <TestimonialsProgress
             testimonialList={data.about.testimonialsText}


### PR DESCRIPTION
Fixed a bug where the child component Testimonials.js was not getting props from About.js, specifically EN, which caused the testimonial text to always appear in VN. I figured this out through the command prompt, since EN was showing up as undefined in the console, which is not the expected behavior.