### PR TITLE
<update> Implemented redirects to home page upon login and logout

### DIFF
--- a/components/Footer.js
+++ b/components/Footer.js
@@ -44,8 +44,6 @@ const Footer = ({ EN }) => {
             <div className={FooterCSS.portalitem} onClick={() => signOut()}>
               {data.footer.portal[2]}
             </div>
-            <div>Hello, {session.user.name}</div>
-            <div>Your name is {session.user.email}</div>
           </div>
           <div className={FooterCSS.newslettercontainer}>
             <div className={FooterCSS.footertitle}>

--- a/pages/api/auth/[...nextauth].js
+++ b/pages/api/auth/[...nextauth].js
@@ -8,4 +8,9 @@ export default NextAuth({
       clientSecret: process.env.REACT_APP_CLIENT_SECRET,
     }),
   ],
+  callbacks: {
+    async redirect({ url, baseUrl }) {
+      return baseUrl;
+    },
+  },
 });


### PR DESCRIPTION
The goal of this PR is to implement redirects to the homepage after any NextAuth behavior is triggered. That is, for example, when the master user logs out on the settings page, the user won't have access to that page anymore (due to the NextAuth middleware.js), so a redirect to the homepage makes sense.